### PR TITLE
Allow historic round start

### DIFF
--- a/classes/external/admin_schedule_round.php
+++ b/classes/external/admin_schedule_round.php
@@ -86,9 +86,6 @@ class admin_schedule_round extends external_api {
         if ($timestart > $timeend) {
             throw new invalid_parameter_exception("start is greater than end");
         }
-        if ($timestart <= time()) {
-            $timestart = time();
-        }
 
         // start renderer
         global $PAGE;


### PR DESCRIPTION
This enhancement allows the start date of rounds to be earlier than the current time and date. This is important for the automated scheduling recurring matches within the round, as they are scheduled with equidistant timing.

Fixes https://github.com/kulmann/moodle-mod_challenge/issues/24

cc @Dmfama20, thanks for reporting this!